### PR TITLE
Add fix to error on jython of wrong-staticness

### DIFF
--- a/src/petablox/program/Program.java
+++ b/src/petablox/program/Program.java
@@ -110,6 +110,10 @@ public class Program {
     	Options.v().set_keep_offset(true);
     	Options.v().set_whole_program(true);
     	Options.v().set_allow_phantom_refs(true);
+
+        if (Config.sootIgnoreStatic) {
+            Options.v().setPhaseOption("jb.tr", "ignore-wrong-staticness:true");
+        }
     	
 		if (Config.reflectKind.equals("external")) {
 			ExtReflectResolver extReflectResolver = new ExtReflectResolver();

--- a/src/petablox/project/Config.java
+++ b/src/petablox/project/Config.java
@@ -171,6 +171,9 @@ public class Config {
         Utils.mkdirs(logicbloxWorkDirName);
     }
 
+    // Properties concerning Soot
+    public final static boolean sootIgnoreStatic = Utils.buildBoolProperty("soot.ignore.static", false);
+
     // commonly-used constants
 
     public final static String mainDirName = System.getProperty("petablox.main.dir");


### PR DESCRIPTION
Fix to #6 

Please inform on the appropriate-ness of the property name `soot.ignore.static`
