### PR TITLE
Add nativeM relation

### DIFF
--- a/doc/program.tex
+++ b/doc/program.tex
@@ -611,7 +611,7 @@ Under construction.
 %};
 %Program program = Program.g();
 %for (jq_Method m : program.getMethods()) {
-%    if (!m.isAbstract()) {
+%    if (m.isConcrete()) {
 %        ControlFlowGraph cfg = m.getCFG();
 %        ListIterator.BasicBlock it = cfg.reversePostOrderIterator();
 %        while (it.hasNext()) {
@@ -625,4 +625,3 @@ Under construction.
 %}
 %\end{verbatim}
 %\end{framed}
-

--- a/src/petablox/analyses/alias/CtxtsAnalysis.java
+++ b/src/petablox/analyses/alias/CtxtsAnalysis.java
@@ -240,7 +240,7 @@ public class CtxtsAnalysis extends JavaAnalysis {
 			for (int mIdx = 0; mIdx < numM; mIdx++) {
 				SootMethod m = domM.get(mIdx);
 				int kind;
-				if (m == mainMeth || m.getName().contains("<clinit>") || m.isAbstract())
+				if (m == mainMeth || m.getName().contains("<clinit>") || !m.isConcrete())
 					kind = CTXTINS;
 				else
 					kind = m.isStatic() ? statCtxtKind : instCtxtKind;

--- a/src/petablox/analyses/alloc/DomH.java
+++ b/src/petablox/analyses/alloc/DomH.java
@@ -71,7 +71,7 @@ public class DomH extends ProgramDom<Object> {
         add(null);    
         for (int mIdx = 0; mIdx < numM; mIdx++) {
             SootMethod m = domM.get(mIdx);
-            if (m.isAbstract())
+            if (!m.isConcrete())
                 continue;
             ICFG cfg = SootUtilities.getCFG(m);
             for (Block bb : cfg.reversePostOrder()) {

--- a/src/petablox/analyses/argret/RelMmethArg.java
+++ b/src/petablox/analyses/argret/RelMmethArg.java
@@ -27,7 +27,7 @@ public class RelMmethArg extends ProgramRel {
         int numM = domM.size();
         for (int mIdx = 0; mIdx < numM; mIdx++) {
             SootMethod m = domM.get(mIdx);
-            if (m.isAbstract())
+            if (!m.isConcrete())
                 continue;
             Local[] rf = SootUtilities.getMethArgLocals(m);
             int numArgs = rf.length;

--- a/src/petablox/analyses/argret/RelThisMV.java
+++ b/src/petablox/analyses/argret/RelThisMV.java
@@ -25,7 +25,7 @@ public class RelThisMV extends ProgramRel {
         int numM = domM.size();
         for (int mIdx = 0; mIdx < numM; mIdx++) {
             SootMethod m = domM.get(mIdx);
-            if (m.isAbstract() || m.isStatic())
+            if (!m.isConcrete() || m.isStatic())
                 continue;
             Local v = m.getActiveBody().getThisLocal();
             int vIdx = domV.indexOf(v);

--- a/src/petablox/analyses/basicblock/DomB.java
+++ b/src/petablox/analyses/basicblock/DomB.java
@@ -21,7 +21,7 @@ public class DomB extends ProgramDom<Block> implements IMethodVisitor {
 
     @Override
     public void visit(SootMethod m) {
-        if (m.isAbstract())
+        if (!m.isConcrete())
             return;
         ICFG cfg = SootUtilities.getCFG(m);
         for (Block b : cfg.reversePostOrder())

--- a/src/petablox/analyses/basicblock/RelEntryP.java
+++ b/src/petablox/analyses/basicblock/RelEntryP.java
@@ -25,7 +25,7 @@ public class RelEntryP extends ProgramRel {
 	 	DomP domP = (DomP) ClassicProject.g().getTrgt("P");
 	 	for (int i = 0; i < domM.size(); i++) { 
 	 		SootMethod m = (SootMethod) domM.get(i);
-	 		if (!m.isAbstract()) {
+	 		if (m.isConcrete()) {
 		 		ICFG cfg = SootUtilities.getCFG(m);
 		 		Unit hnop = cfg.getHeads().get(0).getHead();
 		 		add(domP.indexOf(hnop));

--- a/src/petablox/analyses/basicblock/RelPostDomBB.java
+++ b/src/petablox/analyses/basicblock/RelPostDomBB.java
@@ -30,7 +30,7 @@ public class RelPostDomBB extends ProgramRel implements IMethodVisitor {
         new HashMap<Block, Set<Block>>();
     public void visit(SootClass c) { }
     public void visit(SootMethod m) {
-        if (m.isAbstract())
+        if (!m.isConcrete())
             return;
         pdomMap.clear();
         ICFG cfg = SootUtilities.getCFG(m);

--- a/src/petablox/analyses/escape/metaback/IterThrEscAnalysis.java
+++ b/src/petablox/analyses/escape/metaback/IterThrEscAnalysis.java
@@ -218,7 +218,7 @@ public class IterThrEscAnalysis extends ParallelAnalysis {
 		quadToRPOid = new TObjectIntHashMap<Object>();
 		invkQuadToLoc = new HashMap<Unit, Loc>();
 		for (SootMethod m : cicg.getNodes()) {
-			if (m.isAbstract())
+			if (!m.isConcrete())
 				continue;
 			ICFG cfg = SootUtilities.getCFG(m);
 			quadToRPOid.put(cfg.getHeads().get(0), 0);

--- a/src/petablox/analyses/inst/PhiInstAnalysis.java
+++ b/src/petablox/analyses/inst/PhiInstAnalysis.java
@@ -43,7 +43,7 @@ public class PhiInstAnalysis extends JavaAnalysis {
         relPhiDst.zero();
         relPhiMax.zero();
         for (SootMethod m : Program.g().getMethods()) {
-            if (m.isAbstract())
+            if (!m.isConcrete())
                 continue;
             ICFG cfg = SootUtilities.getCFG(m);
             for (Block bb : cfg.reversePostOrder()) {

--- a/src/petablox/analyses/lock/DomL.java
+++ b/src/petablox/analyses/lock/DomL.java
@@ -35,7 +35,7 @@ public class DomL extends ProgramDom<Unit> implements IAcqLockInstVisitor {
 
     @Override
     public void visit(SootMethod m) {
-        if (m.isAbstract())
+        if (!m.isConcrete())
             return;
         if (m.isSynchronized()) {
             ICFG cfg = SootUtilities.getCFG(m);

--- a/src/petablox/analyses/lock/DomR.java
+++ b/src/petablox/analyses/lock/DomR.java
@@ -34,7 +34,7 @@ public class DomR extends ProgramDom<Unit> implements IRelLockInstVisitor {
 
     @Override
     public void visit(SootMethod m) {
-        if (m.isAbstract())
+        if (!m.isConcrete())
             return;
         if (m.isSynchronized()) {
             ICFG cfg = SootUtilities.getCFG(m);

--- a/src/petablox/analyses/lock/RelLL.java
+++ b/src/petablox/analyses/lock/RelLL.java
@@ -40,7 +40,7 @@ public class RelLL extends ProgramRel implements IMethodVisitor {
     }
     public void visit(SootClass c) { }
     public void visit(SootMethod m) {
-        if (m.isAbstract())
+        if (!m.isConcrete())
             return;
         ICFG cfg = SootUtilities.getCFG(m);
         Block entry = cfg.getHeads().get(0);

--- a/src/petablox/analyses/lock/RelLP.java
+++ b/src/petablox/analyses/lock/RelLP.java
@@ -44,7 +44,7 @@ public class RelLP extends ProgramRel implements IMethodVisitor {
     }
     public void visit(SootClass c) { }
     public void visit(SootMethod m) {
-        if (m.isAbstract())
+        if (!m.isConcrete())
             return;
         ICFG cfg = SootUtilities.getCFG(m);
         Block entry = cfg.getHeads().get(0);

--- a/src/petablox/analyses/method/RelNativeM.java
+++ b/src/petablox/analyses/method/RelNativeM.java
@@ -7,7 +7,7 @@ import petablox.project.Petablox;
 import petablox.project.analyses.ProgramRel;
 
 /**
- * Relation containing all synchronized methods.
+ * Relation containing all native methods.
  *
  * @author Joe Cox (cox@cs.ucla.edu)
  */

--- a/src/petablox/analyses/method/RelNativeM.java
+++ b/src/petablox/analyses/method/RelNativeM.java
@@ -18,7 +18,22 @@ import petablox.project.analyses.ProgramRel;
 public class RelNativeM extends ProgramRel implements IMethodVisitor {
     public void visit(SootClass c) { }
     public void visit(SootMethod m) {
-        if (m.isNative())
+        if (m.isNative()) {
             add(m);
+        }
+        
+        /**
+         * Some native methods are stubbed and had the native modifier removed
+         * to play nice with Soot
+         */
+        if (m.getSignature().equals("<java.lang.Object: java.lang.Object clone()>") ||
+            m.getSignature().equals("<java.lang.System: void arraycopy(java.lang.Object,int,java.lang.Object,int,int)>") ||
+            m.getSignature().equals("<java.lang.reflect.Array: void set(java.lang.Object,int,java.lang.Object)>") ||
+            m.getSignature().equals("<java.security.AccessController: java.lang.Object doPrivileged(java.security.PrivilegedAction)>") ||
+            m.getSignature().equals("<java.security.AccessController: java.lang.Object doPrivileged(java.security.PrivilegedExceptionAction)>") ||
+            m.getSignature().equals("<java.security.AccessController: java.lang.Object doPrivileged(java.security.PrivilegedAction,java.security.AccessControlContext)>") ||
+            m.getSignature().equals("<java.security.AccessController: java.lang.Object doPrivileged(java.security.PrivilegedExceptionAction,java.security.AccessControlContext)>")) {
+            add(m);
+        }
     }
 }

--- a/src/petablox/analyses/method/RelNativeM.java
+++ b/src/petablox/analyses/method/RelNativeM.java
@@ -9,7 +9,7 @@ import petablox.project.analyses.ProgramRel;
 /**
  * Relation containing all synchronized methods.
  *
- * @author Mayur Naik (mhn@cs.stanford.edu)
+ * @author Joe Cox (cox@cs.ucla.edu)
  */
 @Petablox(
     name = "nativeM",

--- a/src/petablox/analyses/method/RelNativeM.java
+++ b/src/petablox/analyses/method/RelNativeM.java
@@ -1,0 +1,24 @@
+package petablox.analyses.method;
+
+import soot.SootClass;
+import soot.SootMethod;
+import petablox.program.visitors.IMethodVisitor;
+import petablox.project.Petablox;
+import petablox.project.analyses.ProgramRel;
+
+/**
+ * Relation containing all synchronized methods.
+ *
+ * @author Mayur Naik (mhn@cs.stanford.edu)
+ */
+@Petablox(
+    name = "nativeM",
+    sign = "M0"
+)
+public class RelNativeM extends ProgramRel implements IMethodVisitor {
+    public void visit(SootClass c) { }
+    public void visit(SootMethod m) {
+        if (m.isNative())
+            add(m);
+    }
+}

--- a/src/petablox/analyses/point/DomP.java
+++ b/src/petablox/analyses/point/DomP.java
@@ -49,7 +49,7 @@ public class DomP extends ProgramDom<Unit> {
         int numM = domM.size();
         for (int mIdx = 0; mIdx < numM; mIdx++) {
             SootMethod m = domM.get(mIdx);
-            if (m.isAbstract())
+            if (!m.isConcrete())
                 continue;
             ICFG cfg = SootUtilities.getCFG(m);
             for (Block bb : cfg.reversePostOrder()) {

--- a/src/petablox/analyses/point/RelMPhead.java
+++ b/src/petablox/analyses/point/RelMPhead.java
@@ -18,7 +18,7 @@ import petablox.util.soot.SootUtilities;
 public class RelMPhead extends ProgramRel implements IMethodVisitor {
     public void visit(SootClass c) { }
     public void visit(SootMethod m) {
-        if (m.isAbstract())
+        if (!m.isConcrete())
             return;
         ICFG cfg = SootUtilities.getCFG(m);
         Unit be = cfg.getHeads().get(0).getHead();

--- a/src/petablox/analyses/point/RelMPtail.java
+++ b/src/petablox/analyses/point/RelMPtail.java
@@ -18,7 +18,7 @@ import petablox.util.soot.SootUtilities;
 public class RelMPtail extends ProgramRel implements IMethodVisitor {
     public void visit(SootClass c) { }
     public void visit(SootMethod m) {
-        if (m.isAbstract())
+        if (!m.isConcrete())
             return;
         ICFG cfg = SootUtilities.getCFG(m);
         Unit bx = cfg.getTails().get(0).getHead();

--- a/src/petablox/analyses/point/RelPP.java
+++ b/src/petablox/analyses/point/RelPP.java
@@ -29,7 +29,7 @@ public class RelPP extends ProgramRel implements IMethodVisitor {
     public void visit(SootClass c) { }
 	@Override
     public void visit(SootMethod m) {
-        if (m.isAbstract())
+        if (!m.isConcrete())
             return;
         ICFG cfg = SootUtilities.getCFG(m);
         for (Block bq : cfg.reversePostOrder()) {

--- a/src/petablox/analyses/provenance/kcfa/CtxtsAnalysis.java
+++ b/src/petablox/analyses/provenance/kcfa/CtxtsAnalysis.java
@@ -234,7 +234,7 @@ public class CtxtsAnalysis extends JavaAnalysis {
 			for (int mIdx = 0; mIdx < numM; mIdx++) {
 				SootMethod m = domM.get(mIdx);
 				int kind;
-				if (m == mainMeth || m.getName().contains("<clinit>") || m.isAbstract())
+				if (m == mainMeth || m.getName().contains("<clinit>") || !m.isConcrete())
 					kind = CTXTINS;
 				else
 					kind = m.isStatic() ? statCtxtKind : instCtxtKind;

--- a/src/petablox/analyses/provenance/kcfa/SimpleCtxtsAnalysis.java
+++ b/src/petablox/analyses/provenance/kcfa/SimpleCtxtsAnalysis.java
@@ -285,7 +285,7 @@ public class SimpleCtxtsAnalysis extends JavaAnalysis {
 			for (int mIdx = 0; mIdx < numM; mIdx++) {
 				SootMethod m = domM.get(mIdx);
 				int kind;
-				if (m == mainMeth || m.getName().contains("<clinit>") || m.isAbstract())
+				if (m == mainMeth || m.getName().contains("<clinit>") || !m.isConcrete())
 					kind = CTXTINS;
 				else
 					kind = m.isStatic() ? statCtxtKind : instCtxtKind;

--- a/src/petablox/analyses/provenance/typestate/RelMK.java
+++ b/src/petablox/analyses/provenance/typestate/RelMK.java
@@ -25,7 +25,7 @@ public class RelMK extends ProgramRel {
         int numM = domM.size();
         for (int mIdx = 0; mIdx < numM; mIdx++) {
             SootMethod m = domM.get(mIdx);
-            if (m.isAbstract())
+            if (!m.isConcrete())
                 continue;
             Local[] args = SootUtilities.getMethArgLocals(m);
             int numRefArgs = 0;

--- a/src/petablox/analyses/provenance/typestate/RelMZZ.java
+++ b/src/petablox/analyses/provenance/typestate/RelMZZ.java
@@ -25,7 +25,7 @@ public class RelMZZ extends ProgramRel {
         int numM = domM.size();
         for (int mIdx = 0; mIdx < numM; mIdx++) {
             SootMethod m = domM.get(mIdx);
-            if (m.isAbstract())
+            if (!m.isConcrete())
                 continue;
             Local[] args = SootUtilities.getMethArgLocals(m);
             int numArgs = args.length;

--- a/src/petablox/analyses/provenance/typestate/RelMZfirst.java
+++ b/src/petablox/analyses/provenance/typestate/RelMZfirst.java
@@ -26,7 +26,7 @@ public class RelMZfirst extends ProgramRel {
         int numM = domM.size();
         for (int mIdx = 0; mIdx < numM; mIdx++) {
             SootMethod m = domM.get(mIdx);
-            if (m.isAbstract())
+            if (!m.isConcrete())
                 continue;
             Local[] args = SootUtilities.getMethArgLocals(m);
             for (int zIdx = 0; zIdx < args.length; zIdx++) {

--- a/src/petablox/analyses/provenance/typestate/RelMZlast.java
+++ b/src/petablox/analyses/provenance/typestate/RelMZlast.java
@@ -26,7 +26,7 @@ public class RelMZlast extends ProgramRel {
         int numM = domM.size();
         for (int mIdx = 0; mIdx < numM; mIdx++) {
             SootMethod m = domM.get(mIdx);
-            if (m.isAbstract())
+            if (!m.isConcrete())
                 continue;
             Local[] args = SootUtilities.getMethArgLocals(m);
             int numArgs = args.length;

--- a/src/petablox/analyses/reflect/ConNewInstAnalysis.java
+++ b/src/petablox/analyses/reflect/ConNewInstAnalysis.java
@@ -67,7 +67,7 @@ public class ConNewInstAnalysis extends JavaAnalysis {
                     List<SootMethod> meths = c.getMethods();
                     for (int i = 0; i < meths.size(); i++) {
                     	SootMethod m = meths.get(i);
-                    	if(m.isAbstract() || m.isStatic())
+                    	if(!m.isConcrete() || m.isStatic())
                     		continue;
                         if (m.getName().toString().equals("<init>")) {
                             int mIdx = domM.indexOf(m);
@@ -82,4 +82,3 @@ public class ConNewInstAnalysis extends JavaAnalysis {
         relConNewInstIM.save();
     }
 }
-

--- a/src/petablox/analyses/var/DomV.java
+++ b/src/petablox/analyses/var/DomV.java
@@ -52,7 +52,7 @@ public class DomV extends ProgramDom<Local> implements IMethodVisitor {
 
     @Override
     public void visit(SootMethod m) {
-        if (m.isAbstract())
+        if (!m.isConcrete())
             return;
         List<Local> vars = SootUtilities.getLocals(m);
         Iterator<Local> varsIt = vars.iterator();

--- a/src/petablox/analyses/var/RelVT.java
+++ b/src/petablox/analyses/var/RelVT.java
@@ -48,7 +48,7 @@ public class RelVT extends ProgramRel implements IMethodVisitor {
     }
     public void visit(SootClass c) { }
     public void visit(SootMethod m) {
-        if (m.isAbstract())
+        if (!m.isConcrete())
             return;
         /*ICFG cfg = SootUtilities.getCFG(m);
         Local[] regs = SootUtilities.getMethArgLocals(m);
@@ -91,4 +91,3 @@ public class RelVT extends ProgramRel implements IMethodVisitor {
     	}
     }
 }
-

--- a/src/petablox/program/CHA.java
+++ b/src/petablox/program/CHA.java
@@ -119,7 +119,7 @@ public class CHA implements ScopeBuilder {
     
     private void visitMethod(SootMethod m) {
         if (methods.add(m)) {
-            if (!m.isAbstract()) {
+            if (m.isConcrete()) {
                 if (DEBUG) System.out.println("\tAdding method: " + m);
                 methodWorklist.add(m);
             }

--- a/src/petablox/program/DynamicBuilder.java
+++ b/src/petablox/program/DynamicBuilder.java
@@ -39,7 +39,7 @@ public class DynamicBuilder implements ScopeBuilder {
             classes.add(rc);
             List<SootMethod> meths = c.getMethods();
             for(SootMethod m : meths){
-            	if(!m.isAbstract())
+            	if(m.isConcrete())
             		m.releaseActiveBody();
             	methods.add(m);
             }

--- a/src/petablox/program/Program.java
+++ b/src/petablox/program/Program.java
@@ -959,7 +959,7 @@ public class Program {
     
     private void printMethod(SootMethod m) {
         System.out.println("Method: " + m);
-        if (!m.isAbstract()) {
+        if (m.isConcrete()) {
         	Body b = m.retrieveActiveBody();
             System.out.println(b.toString());
         }
@@ -993,4 +993,3 @@ public class Program {
             printClass(c);
     }
 }
-

--- a/src/petablox/program/RTA.java
+++ b/src/petablox/program/RTA.java
@@ -305,7 +305,7 @@ public class RTA implements ScopeBuilder {
         }
         if (methods.add(s)) {
             if (DEBUG) System.out.println("\tAdding method: " + s);
-            if (!s.isAbstract() && !s.isNative()) {
+            if (s.isConcrete()) {
                 methodWorklist.add(s);
             }
         }

--- a/src/petablox/program/RTA.java
+++ b/src/petablox/program/RTA.java
@@ -305,7 +305,7 @@ public class RTA implements ScopeBuilder {
         }
         if (methods.add(s)) {
             if (DEBUG) System.out.println("\tAdding method: " + s);
-            if (!s.isAbstract()) {
+            if (!s.isAbstract() && !s.isNative()) {
                 methodWorklist.add(s);
             }
         }

--- a/src/petablox/project/VisitorHandler.java
+++ b/src/petablox/project/VisitorHandler.java
@@ -97,7 +97,7 @@ public class VisitorHandler {
                     mv.visit(m);
                     if (!doCFGs)
                         continue;
-                    if (m.isAbstract())
+                    if (!m.isConcrete())
                         continue;
                     ICFG cfg = SootUtilities.getCFG(m);
                     visitInsts(cfg);

--- a/src/petablox/project/analyses/rhs/RHSAnalysis.java
+++ b/src/petablox/project/analyses/rhs/RHSAnalysis.java
@@ -199,7 +199,7 @@ public abstract class RHSAnalysis<PE extends IEdge, SE extends IEdge> extends Ja
         quadToRPOid = new TObjectIntHashMap<Unit>();
         invkQuadToLoc = new HashMap<Unit, Loc>();
         for (SootMethod m : cicg.getNodes()) {
-            if (m.isAbstract()) continue;
+            if (!m.isConcrete()) continue;
             ICFG cfg = SootUtilities.getCFG(m);
             quadToRPOid.put(cfg.getHeads().get(0).getHead(), 0);
             int rpoId = 1;
@@ -779,4 +779,3 @@ public abstract class RHSAnalysis<PE extends IEdge, SE extends IEdge> extends Ja
         wpeMap.put(new Pair<Unit, PE>(i, peCopy), wpe);
     }
 }
-

--- a/src/petablox/util/soot/StubMethodSupport.java
+++ b/src/petablox/util/soot/StubMethodSupport.java
@@ -47,6 +47,11 @@ public class StubMethodSupport {
 		return false;
 	}
 	
+	/**
+	 * Creates a skeleton SootMethod with a simple body if the method is concrete.
+	 * removeNative allows for stubbed native methods -- it is necessary to remove
+	 *   the native modifier for anything given a body
+	 */
 	private static SootMethod genericMethod(SootMethod m, boolean removeSync, boolean removeNative) {
 		SootClass c = m.getDeclaringClass();
 		SootMethod s = new SootMethod(m.getName(), m.getParameterTypes(), m.getReturnType(), m.getModifiers());

--- a/src/petablox/util/soot/StubMethodSupport.java
+++ b/src/petablox/util/soot/StubMethodSupport.java
@@ -47,12 +47,16 @@ public class StubMethodSupport {
 		return false;
 	}
 	
-	private static SootMethod genericMethod(SootMethod m, boolean removeSync) {
+	private static SootMethod genericMethod(SootMethod m, boolean removeSync, boolean removeNative) {
 		SootClass c = m.getDeclaringClass();
-		SootMethod s = new SootMethod(m.getName(), m.getParameterTypes(), m.getReturnType(), m.getModifiers() & ~Modifier.NATIVE);
+		SootMethod s = new SootMethod(m.getName(), m.getParameterTypes(), m.getReturnType(), m.getModifiers());
+		
+		if (removeNative) s.setModifiers(s.getModifiers() & ~Modifier.NATIVE);
 		if (removeSync) s.setModifiers(s.getModifiers() & ~Modifier.SYNCHRONIZED);
+		
 		c.removeMethod(m);
 		c.addMethod(s);
+		
 		if (s.isConcrete()) {
 			JimpleBody body = Jimple.v().newBody(s);
 			Chain<Unit> units = body.getUnits();
@@ -79,7 +83,7 @@ public class StubMethodSupport {
 	 * Stub for instance method "void start()" in class java.lang.Thread.
 	 */	
 	private static SootMethod getThreadStartEquiv(SootMethod m) {
-		SootMethod s = genericMethod(m, true);
+		SootMethod s = genericMethod(m, true, false);
 		JimpleBody body =(JimpleBody) s.retrieveActiveBody();
 		SootClass c = s.getDeclaringClass();
 		String runSig = "void run()";
@@ -98,7 +102,7 @@ public class StubMethodSupport {
 	 * Stub for instance method "java.lang.Object clone()" in class java.lang.Object.
 	 */
 	private static SootMethod getCloneEquiv(SootMethod m) {
-		SootMethod s = genericMethod(m, false);
+		SootMethod s = genericMethod(m, false, true);
 		JimpleBody body =(JimpleBody) s.retrieveActiveBody();
 		SootClass c = s.getDeclaringClass();
 		Chain<Unit> units = body.getUnits();
@@ -125,7 +129,7 @@ public class StubMethodSupport {
 	 * return
 	 */
 	private static SootMethod getArrayCopyEquiv(SootMethod m) {
-		SootMethod s = genericMethod(m, false);
+		SootMethod s = genericMethod(m, false, true);
 		JimpleBody body =(JimpleBody) s.retrieveActiveBody();
 		SootClass c = s.getDeclaringClass();
 		Chain<Unit> units = body.getUnits();
@@ -173,7 +177,7 @@ public class StubMethodSupport {
 	 * return
 	 */
 	private static SootMethod getArraySetEquiv(SootMethod m) {
-		SootMethod s = genericMethod(m, false);
+		SootMethod s = genericMethod(m, false, true);
 		JimpleBody body =(JimpleBody) s.retrieveActiveBody();
 		SootClass c = s.getDeclaringClass();
 		Chain<Unit> units = body.getUnits();
@@ -208,7 +212,7 @@ public class StubMethodSupport {
 	 * return t0
 	 */
 	private static SootMethod getDoPrivileged(SootMethod m){
-		SootMethod s = genericMethod(m,false);
+		SootMethod s = genericMethod(m, false, true);
 		JimpleBody body =(JimpleBody) s.retrieveActiveBody();
 		List<Type> paramTypes = m.getParameterTypes();
 		RefType param1 = (RefType)paramTypes.get(0);
@@ -232,7 +236,7 @@ public class StubMethodSupport {
 	 * Empty stub for unsupported native methods / excluded methods
 	 */
 	public static SootMethod emptyStub(SootMethod m) {
-        SootMethod s = genericMethod(m, false);
+        SootMethod s = genericMethod(m, false, false);
         if (s.isConcrete()) {
 			JimpleBody body =(JimpleBody) s.retrieveActiveBody();
 			SootClass c = s.getDeclaringClass();


### PR DESCRIPTION
The `nativeM` relation represents native methods.  

Native methods retain their `NATIVE` Java modifier and are excluded from the list of methods to be processed (since they don't have bodies).  These are added to the relation based on the existence of the modifier.

The exceptions are the native methods which are simulated by Petablox, like `arraycopy`.  The `NATIVE` modifier must be removed for Soot to allow them to have a body.  These methods are added manually to the relation.

Knowing which methods are native is important for the information flow analysis I do in my research.
